### PR TITLE
Move stats to top of document

### DIFF
--- a/lib/buster-test/reporters/html.js
+++ b/lib/buster-test/reporters/html.js
@@ -132,7 +132,10 @@
 
         addStats: function (stats) {
             var diff = (new Date() - this.startedAt) / 1000;
-            var statsEl = el(this.doc, "div", { className: "stats" });
+
+            var className = "stats " + (this.success(stats) ? "success" : "failure");
+            var statsEl = el(this.doc, "div", { className: className });
+
             var h1 = this.doc.getElementsByTagName("h1")[0];
             this.root.insertBefore(statsEl, h1.nextSibling);
 

--- a/resources/buster-test.css
+++ b/resources/buster-test.css
@@ -50,8 +50,13 @@ body.buster-test {
 
 .buster-test .timeout h3,
 .buster-test .failure h3,
-.buster-test .error-message {
+.buster-test .error-message,
+.buster-test .stats.failure {
     color: #c33;
+}
+
+.buster-test .stats.success {
+    color: #3c3;
 }
 
 .buster-test .error h3,

--- a/test/unit/buster-test/reporters/html-test.js
+++ b/test/unit/buster-test/reporters/html-test.js
@@ -506,7 +506,19 @@
             this.reporter.addStats({});
             var h1 = this.root.getElementsByTagName('h1')[0];
             assert.equals(this.stats(), h1.nextSibling);
-        }
+        },
+
+        "should have the success class when all successful": function() {
+            sinon.stub(this.reporter, 'success').returns(true);
+            this.reporter.addStats({});
+            assert.className(this.stats(), 'success');
+        },
+
+        "should have the failure class when not all successful": function() {
+            sinon.stub(this.reporter, 'success').returns(false);
+            this.reporter.addStats({});
+            assert.className(this.stats(), 'failure');
+        },
     });
 
     busterUtil.testCase("HTMLReporterEventMappingTest", sinon.testCase({


### PR DESCRIPTION
When running a lot of tests using `buster static`, it's not obvious whether all the tests passed without scrolling to the bottom of the page.

This moves the stats div to the top of the page, and styles it green or red based on success or failure of the whole suite.
