### PR TITLE
Treat describe("Foo") as a deferred spec.

### DIFF
--- a/lib/buster-test/spec.js
+++ b/lib/buster-test/spec.js
@@ -44,6 +44,9 @@
     }
 
     bspec.describe = function (name, spec) {
+        if (spec === undefined) {
+            spec = function() { bspec.it(name); };
+        }
         if (current.length > 0) {
             return addContext(current[current.length - 1], name, spec);
         }

--- a/test/unit/buster-test/spec-test.js
+++ b/test/unit/buster-test/spec-test.js
@@ -33,16 +33,17 @@
             });
         },
 
-        "throws without spec": function () {
-            assert.exception(function () {
-                var spec = bspec.describe("Some test");
-            });
-        },
-
         "throws if specs is not a function": function () {
             assert.exception(function () {
                 var spec = bspec.describe("Some test", {});
             });
+        },
+
+        "treats empty describe as deferred": function () {
+            var spec = bspec.describe("Deferred");
+
+            assert.equals("Deferred", spec.tests[0].name);
+            assert(spec.tests[0].deferred);
         },
 
         "returns context object": function () {


### PR DESCRIPTION
If no second argument is passed to describe, create a single deferred
it() as its context.

Fixes busterjs/buster#129
