### PR TITLE
better header style for browser static tests on IE

### DIFF
--- a/resources/buster-test.css
+++ b/resources/buster-test.css
@@ -134,6 +134,7 @@ body.buster-test {
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#ff5f5f5f, endColorstr=#ff222222);
     /* For Internet Explorer 8 */
     -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#ff5f5f5f, endColorstr=#ff222222)";
+    zoom: 1;
 
     border-bottom: 4px solid #c0c6cc;
     box-shadow: 0 0 10px #ddd;


### PR DESCRIPTION
A hack for IE that will make the header look exactly like it does on the other browsers. from this: http://cl.ly/2e451X3c3B0X221Q3Y3N to this: http://cl.ly/2e451X3c3B0X221Q3Y3N
