### PR TITLE
Adds bspec.beforeEach() and bspec.afterEach()

### DIFF
--- a/lib/buster-test/spec.js
+++ b/lib/buster-test/spec.js
@@ -90,12 +90,12 @@
         return bspec.it(name, comment, func);
     };
 
-    bspec.before = function (func) {
+    bspec.before = bspec.beforeEach = function (func) {
         var context = current[current.length - 1];
         context.setUp = func;
     };
 
-    bspec.after = function (func) {
+    bspec.after = bspec.afterEach = function (func) {
         var context = current[current.length - 1];
         context.tearDown = func;
     };
@@ -125,7 +125,9 @@
 
             this.testCase = {
                 before: bspec.before,
+                beforeEach: bspec.beforeEach,
                 after: bspec.after,
+                afterEach: bspec.afterEach,
                 it: bspec.it,
                 itEventually: bspec.itEventually,
                 describe: bspec.describe
@@ -150,7 +152,9 @@
         env.it = bspec.it;
         env.itEventually = bspec.itEventually;
         env.before = bspec.before;
+        env.beforeEach = bspec.beforeEach;
         env.after = bspec.after;
+        env.afterEach = bspec.afterEach;
     };
 
     if (typeof module == "object") {

--- a/test/unit/buster-test/spec-test.js
+++ b/test/unit/buster-test/spec-test.js
@@ -189,11 +189,31 @@
             assert.equals(setUp, spec.setUp);
         },
 
-        "adds setUp function by calling this..before": function () {
+        "adds setUp function by calling bspec.beforeEach": function () {
+            var setUp = function () {};
+
+            var spec = bspec.describe("Stuff", function () {
+                bspec.beforeEach(setUp);
+            });
+
+            assert.equals(setUp, spec.setUp);
+        },
+
+        "adds setUp function by calling this.before": function () {
             var setUp = function () {};
 
             var spec = bspec.describe("Stuff", function () {
                 this.before(setUp);
+            });
+
+            assert.equals(setUp, spec.setUp);
+        },
+
+        "adds setUp function by calling this.beforeEach": function () {
+            var setUp = function () {};
+
+            var spec = bspec.describe("Stuff", function () {
+                this.beforeEach(setUp);
             });
 
             assert.equals(setUp, spec.setUp);
@@ -204,6 +224,26 @@
 
             var spec = bspec.describe("Stuff", function () {
                 bspec.after(tearDown);
+            });
+
+            assert.equals(tearDown, spec.tearDown);
+        },
+
+        "adds tearDown function by calling bspec.afterEach": function () {
+            var tearDown = function () {};
+
+            var spec = bspec.describe("Stuff", function () {
+                bspec.afterEach(tearDown);
+            });
+
+            assert.equals(tearDown, spec.tearDown);
+        },
+
+        "adds tearDown function by calling this.afterEach": function () {
+            var tearDown = function () {};
+
+            var spec = bspec.describe("Stuff", function () {
+                this.afterEach(tearDown);
             });
 
             assert.equals(tearDown, spec.tearDown);
@@ -226,7 +266,9 @@
 
             var spec = bspec.describe("Spec", function () {
                 bspec.before(function () {});
+                bspec.beforeEach(function () {});
                 bspec.after(function () {});
+                bspec.afterEach(function () {});
 
                 bspec.it("test1", funcs[0]);
                 bspec.it("test2", funcs[1]);
@@ -310,11 +352,13 @@
             bspec.expose(this.env);
         },
 
-        "calls exposed describe, it, itEventually, before and after": function () {
+        "calls exposed describe, it, itEventually, before, beforeEach, after and afterEach": function () {
             var env = this.env;
             var test = function () {};
             var before = function () {};
+            var beforeEach = function () {};
             var after = function () {};
+            var afterEach = function () {};
             var eventually = function () {};
 
             var spec = env.describe("Stuff", function () {
@@ -324,12 +368,20 @@
                 env.itEventually("sometime", eventually);
             });
 
+            // Cannot test these in the same context as before() and after()
+            var beforeAfterEachSpec = env.describe("More Stuff", function() {
+                env.beforeEach(beforeEach);
+                env.afterEach(afterEach);
+            });
+
             assert.equals(2, spec.tests.length);
             assert.equals("does it", spec.tests[0].name);
             assert.equals(test, spec.tests[0].func);
             assert.equals("sometime", spec.tests[1].name);
             assert.equals(before, spec.setUp);
             assert.equals(after, spec.tearDown);
+            assert.equals(beforeEach, beforeAfterEachSpec.setUp);
+            assert.equals(afterEach, beforeAfterEachSpec.tearDown);
         },
 
         "parses nested spec properly": function () {


### PR DESCRIPTION
Aliased to bspec.before() and bspec.after().  Also exposed by
buster.spec.expose().

See busterjs/buster#41
