### PR TITLE
Fixes issue #181

### DIFF
--- a/lib/buster-test/reporters/xml.js
+++ b/lib/buster-test/reporters/xml.js
@@ -139,7 +139,7 @@ if (typeof module === "object" && typeof require === "function") {
                 this.io.print("        <testcase time=\"" +
                               elapsedInSec(tests[i].elapsed) +
                               "\" classname=\"" + tests[i].context +
-                              "\" name=\"" + tests[i].name + "\"");
+                              "\" name=\"" + escape(tests[i].name) + "\"");
 
                 if (tests[i].errors.length + tests[i].failures.length > 0) {
                     this.io.print(">\n");

--- a/test/unit/buster-test/reporters/xml-test.js
+++ b/test/unit/buster-test/reporters/xml-test.js
@@ -307,6 +307,13 @@ busterUtil.testCase("XMLReporterTest", sinon.testCase({
         this.assertIO('<failure type="Error" message="&lt;Oops&gt; &amp; stuff">');
     },
 
+    "should escape quotes in test names": function () {
+        this.reporter.contextStart({ name: "Context" });
+        this.reporter.testSuccess({ name: 'it tests the "foo" part'});
+        this.reporter.contextEnd({ name: "Context" });
+        this.assertIO(/name="it tests the &quot;foo&quot; part".*/);
+    },
+
     "should escape stack trace": function () {
         this.reporter.contextStart({ name: "Context" });
         this.reporter.testError({ name: "#1", error: {


### PR DESCRIPTION
Test names containing quotes and other characters might break the xml, so they
should be escaped.
