### PR TITLE
Allow more control over CSS when root element is body

### DIFF
--- a/lib/buster-test/reporters/html.js
+++ b/lib/buster-test/reporters/html.js
@@ -20,13 +20,15 @@
             opt = opt || {};
             reporter.contexts = [];
             reporter.doc = getDoc(opt);
-            reporter.setRoot(opt.root || reporter.doc.body);
+            var cssPath = opt.cssPath;
+            if (!cssPath && opt.detectCssPath) cssPath = busterTestPath(reporter.doc) + "buster-test.css";
+            reporter.setRoot(opt.root || reporter.doc.body, cssPath);
             reporter.io = opt.io || (isNodeJS && require("util"));
 
             return reporter;
         },
 
-        setRoot: function (root) {
+        setRoot: function (root, cssPath) {
             this.root = root;
             this.root.className += " buster-test";
             var body = this.doc.body;
@@ -45,7 +47,7 @@
                     "content": "text/html; charset=utf-8"
                 }));
 
-                addCSS(head);
+                if (cssPath) addCSS(head, cssPath);
                 insertTitle(this.doc, body, this.doc.title || "Buster.JS Test case");
                 insertLogo(this.doc.getElementsByTagName("h1")[0]);
             }
@@ -196,7 +198,7 @@
             (typeof document != "undefined" ? document : createDocument());
     }
 
-    function addCSS(head) {
+    function addCSS(head, cssPath) {
         if (isNodeJS) {
             var fs = require("fs");
             var path = require("path");
@@ -210,7 +212,7 @@
                 rel: "stylesheet",
                 type: "text/css",
                 media: "all",
-                href: busterTestPath() + "buster-test.css"
+                href: cssPath
             }));
         }
     }
@@ -301,7 +303,7 @@
         }
     }
 
-    function busterTestPath() {
+    function busterTestPath(document) {
         var scripts = document.getElementsByTagName("script");
 
         for (var i = 0, l = scripts.length; i < l; ++i) {

--- a/test/unit/buster-test/reporters/html-test.js
+++ b/test/unit/buster-test/reporters/html-test.js
@@ -118,10 +118,37 @@
             assert.equals(meta.content, "text/html; charset=utf-8");
         },
 
-        "should inject CSS file from same directory if buster-test.js is not found":
+        "should use custom CSS file when specified by cssPath option":
+        function () {
+            if (typeof document == "undefined") return;
+            htmlReporter.create({ document: this.doc, root: this.doc.body, cssPath: 'custom.css' });
+
+            var links = this.doc.getElementsByTagName("link");
+            var link = links[links.length - 1];
+
+            assert.match(link, {
+                rel: "stylesheet",
+                type: "text/css",
+                media: "all",
+                href: "custom.css"
+            });
+        },
+
+        "should not inject CSS file unless detectCssPath option is passed":
         function () {
             if (typeof document == "undefined") return;
             htmlReporter.create({ document: this.doc, root: this.doc.body });
+
+            var links = this.doc.getElementsByTagName("link");
+            var link = links[links.length - 1];
+
+            refute.equals(link.href, "buster-test.css");
+        },
+
+        "should inject CSS file from same directory if buster-test.js is not found":
+        function () {
+            if (typeof document == "undefined") return;
+            htmlReporter.create({ document: this.doc, root: this.doc.body, detectCssPath: true });
 
             var links = this.doc.getElementsByTagName("link");
             var link = links[links.length - 1];
@@ -137,7 +164,7 @@
         "should inject CSS file if logging on body": function () {
             if (typeof document == "undefined") return;
             this.doc.body.innerHTML += "<script src=\"/some/path/buster-test.js\"></script>";
-            htmlReporter.create({ document: this.doc, root: this.doc.body });
+            htmlReporter.create({ document: this.doc, root: this.doc.body, detectCssPath: true });
 
             var links = this.doc.getElementsByTagName("link");
             var link = links[links.length - 1];
@@ -152,7 +179,7 @@
 
         "should inject CSS file in style tag if on node": function () {
             if (typeof document != "undefined") return;
-            htmlReporter.create({ document: this.doc, root: this.doc.body });
+            htmlReporter.create({ document: this.doc, root: this.doc.body, detectCssPath: true });
 
             var styles = this.doc.getElementsByTagName("style");
             var style = styles[styles.length - 1];
@@ -443,7 +470,8 @@
                 reporterSetUp.call(this, {
                     document: this.doc,
                     root: this.doc.body,
-                    io: this.io
+                    io: this.io,
+                    detectCssPath: true
                 });
             },
 


### PR DESCRIPTION
I'm making some experiments to see how hard it would be for me to customize the test runner for usage with the Rails asset pipeline.

So, I've added the CSS to the asset pipeline but if I create an HTML reporter using body as the root option, there is no current way to prevent buster-test to try to add the CSS style element to the body.

I've also tried a small hack by creating an empty buster-test.js file in the assets path, but the Asset Pipeline would add an extra argument to it so that the src would be something like "/assets/buster/buster-test.js?body=1" and the regular expression currently in use wouldn't recognize it to find busterTestPath().

This pull request will allow me to prevent the reporter from trying to create the style element in the first place if I pass {cssPath: false} to the options. Alternatively I could pass {cssPath: '/assets/buster/html-report.css'}.
