### PR TITLE
Make addListItem a member of the HTML reporter

### DIFF
--- a/lib/buster-test/reporters/html.js
+++ b/lib/buster-test/reporters/html.js
@@ -89,28 +89,28 @@
         },
 
         testSuccess: function (test) {
-            var li = this.addListItem("h3", test, "success");
+            var li = this.reportTest(test, "success");
             this.addMessages(li);
         },
 
         testFailure: function (test) {
-            var li = this.addListItem("h3", test, "failure");
+            var li = this.reportTest(test, "failure");
             this.addMessages(li);
             addException(li, test.error);
         },
 
         testError: function (test) {
-            var li = this.addListItem("h3", test, "error");
+            var li = this.reportTest(test, "error");
             this.addMessages(li);
             addException(li, test.error);
         },
 
         testDeferred: function (test) {
-            var li = this.addListItem("h3", test, "deferred");
+            var li = this.reportTest(test, "deferred");
         },
 
         testTimeout: function (test) {
-            var li = this.addListItem("h3", test, "timeout");
+            var li = this.reportTest(test, "timeout");
             var source = test.error && test.error.source;
             if (source) {
                 li.firstChild.innerHTML += " (" + source + " timed out)";
@@ -118,13 +118,10 @@
             this.addMessages(li);
         },
 
-        addListItem: function (tagName, test, className) {
-            var prefix = tagName ? "<" + tagName + ">" : "";
-            var suffix = tagName ? "</" + tagName + ">" : "";
-
+        reportTest: function (test, className) {
             var item = el(this.doc, "li", {
                 className: className,
-                text: prefix + test.name + suffix
+                text: '<h3>' + test.name + '</h3>'
             });
 
             this.list().appendChild(item);


### PR DESCRIPTION
This makes it possible to easily override it to include
a link for running a single example, for instance.
