### PR TITLE
Remove arguments from promise callback

### DIFF
--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -236,7 +236,7 @@
             return function () {
                 complete = true;
                 clearTimeout(timer);
-                if (!timedout) { callbacks[method].apply(this, arguments); }
+                if (!timedout) { callbacks[method].apply(this); }
             };
         }
         when(promise).then(handler("resolve"), handler("reject"));


### PR DESCRIPTION
Hi, I ran into some really strange behaviour when using [Q](https://github.com/kriskowal/q)'s `#all` method with BusterJS.

I put together a simple test case here: https://github.com/matthew-andrews/buster-bug, specifically [in this file](https://github.com/matthew-andrews/buster-bug/blob/master/test/tests/case.js).

It turns out any non-falsey value (`Q.all` returns an array of the results of each promise - which in my case was `[undefined, undefined]` but actually even something as simple as `true`, which I use in my test case, breaks Buster) passed back through a promise gets interpreted by as an error and the test fails.

I'm not completely sure whether the fix should be on this line or the line that is reading the error out of the callback.

(Which I suspect to be this one: `var e = err || err2 || this.queued;` on line 604)

And it might be that the arguments _should_ be returned if the promise is rejected.

I'm happy to update this PR with any feedback, and I'd love to add a test to your test suite but I couldn't get them to run following the instructions on the readme on Chrome...

Thanks for making an (otherwise) awesome library :smile: !
