### PR TITLE
Fix for issue #238 for spec

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -1,5 +1,6 @@
 ((typeof define === "function" && define.amd && function (m) {
-    define("buster-test/spec", ["lodash", "when", "buster-test/test-context"], m);
+    define("buster-test/spec", ["lodash", "when", "buster-test/test-context"],
+        m);
 }) || (typeof module === "object" &&
        typeof require === "function" && function (m) {
         module.exports = m(require("lodash"),
@@ -45,7 +46,7 @@
         callback(function (spec) {
             d.resolver.resolve(createContext(name, spec));
         });
-        //d.promise.name = "deferred " + name;
+        d.promise.name = name;
         testContext.emit("create", d.promise);
         return d.promise;
     }

--- a/test/spec-test.js
+++ b/test/spec-test.js
@@ -480,10 +480,15 @@
             var spec = bspec.describe("Some spec", function (run) {});
 
             assert.equals(typeof spec.then, "function");
-            refute.defined(spec.name);
             refute.defined(spec.tests);
             refute.defined(spec.setUp);
             refute.defined(spec.tearDown);
+        },
+
+        "gives context promise name": function () {
+            var spec = bspec.describe("Some spec", function () {});
+
+            assert.equals(spec.name, "Some spec");
         },
 
         "calls async context with run argument": function () {


### PR DESCRIPTION
That fix is needed to have a context name if using `describe` and `run`.
