### PR TITLE
Add mandatory time attribute for testcase with Uncaught exception

### DIFF
--- a/lib/reporters/xml.js
+++ b/lib/reporters/xml.js
@@ -31,7 +31,7 @@
     }
 
     function renderUncaught(error, i) {
-        this.writeln("        <testcase classname=\"Uncaught exception\" " +
+        this.writeln("        <testcase classname=\"Uncaught exception\" time=\"0\"" +
                      "name=\"#" + (i + 1) + "\">");
         this.renderErrors([error]);
         this.writeln("        </testcase>");


### PR DESCRIPTION
The time attribute is mandatory: http://windyroad.com.au/dl/Open%20Source/JUnit.xsd so it should be added in this case as well. (It could cause parsing issues with other tools, like Sonar)
