### PR TITLE
Fixed async callback to handle error objects

### DIFF
--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -202,6 +202,7 @@
         }
 
         return function (fn) {
+            if (fn instanceof Error) { return resolve("reject", fn); }
             if (typeof fn !== "function") { return resolve("resolve"); }
             return function () {
                 try {


### PR DESCRIPTION
I was trying out supertest, which is an excellent library for testing express applications (https://github.com/visionmedia/supertest). It states that it supports all frameworks, but I ran into a problem with Buster. It seems to be a general convention that the "done" async callback can receive an Error object as its first argument, but Buster does not handle that.

So added the line below. Hopefully it is a good place to put it. I could not find any tests related to this functionality so I did not write one.
