### PR TITLE
Add quotes to `class` property in html2 reporter

### DIFF
--- a/lib/reporters/html2.js
+++ b/lib/reporters/html2.js
@@ -259,7 +259,7 @@
         "context:start": function (context) {
             var container = this.elements.runContainer;
             container.appendChild(el(this.doc, "h2", { text: context.name }));
-            this.list = el(this.doc, "table", { class: "table table-striped" });
+            this.list = el(this.doc, "table", { "class": "table table-striped" });
             container.appendChild(this.list);
         },
 


### PR DESCRIPTION
`class` is a reserved word and IE <=8 will throw an error without the quotes.
