### PR TITLE
adding option to have reporters even if you have a document 

### DIFF
--- a/lib/auto-run.js
+++ b/lib/auto-run.js
@@ -88,7 +88,7 @@
         var reporter;
 
         if (typeof document !== "undefined" && document.getElementById) {
-            reporter = "html";
+            reporter = opt.reporter || "html";
             opt.root = document.getElementById("buster") || document.body;
         } else {
             reporter = opt.reporter || "brief";


### PR DESCRIPTION
simulation like jsdom running

useful for CI builds (jenkins) that create xml outputs but test dom interactions
