### PR TITLE
Call `suite:end` even if `runContexts()` gets rejected

### DIFF
--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -163,9 +163,9 @@
         return err && err.name === "AssertionError";
     }
 
-    function prepareResults(results) {
+    function prepareResults(results, error) {
         return _.extend({}, results, {
-            ok: results.failures + results.errors + results.timeouts === 0
+            ok: (results.failures + results.errors + results.timeouts === 0) && !(error instanceof Error)
         });
     }
 
@@ -471,25 +471,37 @@
         },
 
         runSuite: function (ctxs) {
+            var runSuitePromise;
+
             this.focusMode = _.some(ctxs, function (c) { return c.focused; });
             this.results = initializeResults();
             onUncaught(_.bind(function (err) {
                 testResult(this, this.currentTest, err);
             }, this));
-            var d = when.defer();
             this.emit("suite:start", { uuid: this.runtime && this.runtime.uuid });
             if (this.runtime) { emitConfiguration(this, ctxs); }
             if (this.focusMode) {
                 this.emit("runner:focus", { uuid: this.runtime && this.runtime.uuid });
             }
             this.results.contexts = ctxs.length;
-            this.runContexts(ctxs).then(_.bind(function () {
-                var res = prepareResults(this.results);
+
+            if (ctxs.length == 0) {
+                runSuitePromise = when.reject(new Error("No contexts"));
+            }
+            if (!runSuitePromise) {
+                runSuitePromise = this.runContexts(ctxs);
+            }
+
+            return runSuitePromise.always(_.bind(function (e) {
+                var res = prepareResults(this.results, e);
                 res.uuid = this.runtime && this.runtime.uuid;
                 this.emit("suite:end", res);
-                d.resolve(res);
-            }, this), d.reject);
-            return d.promise;
+                if (e instanceof Error) {
+                    // @todo: this error should be displayed somewhere!
+                    throw e; // rethrow to reject the promise
+                }
+                return res;
+            }, this));
         },
 
         runContexts: function (contexts, thisProto) {

--- a/test/test-runner-test.js
+++ b/test/test-runner-test.js
@@ -782,6 +782,15 @@
                 assert(tests[0].calledOnce);
                 assert(tests[1].calledOnce);
             }));
+        },
+
+        "rejects when no contexts provided": function (done) {
+            var onSuiteEnd = sinon.spy();
+            this.runner.on('suite:end', onSuiteEnd);
+            this.runner.runSuite([]).then(null, done(function () {
+                assert(onSuiteEnd.calledOnce, "Should still emit `suite:end`");
+                refute(onSuiteEnd.getCall(0).args[0].ok, "`suite:end` should emit with result.ok == false");
+            }));
         }
     });
 


### PR DESCRIPTION
In case some promise is rejected inside `TestRunner.runContexts`, the `suite:end` event would never get emitted - this causes the runner to hang, as nothing ever really checks for the promise result.

This is a precursor to fix https://github.com/busterjs/buster/issues/327
