### PR TITLE
don't crash when failed to determine context

### DIFF
--- a/lib/reporters/brief.js
+++ b/lib/reporters/brief.js
@@ -331,7 +331,8 @@ BriefReporter.prototype = module.exports = {
     },
 
     "uncaughtException": function (e) {
-        var ua = getEnv(this.runtimes, e).description;
+        var env = getEnv(this.runtimes, e);
+        var ua = env ? env.description : "Unknown context";
         this.clearSummary();
         this.writeln(this.color.yellow("Uncaught exception in " + ua + ":\n"));
         this.writeln(formatStack(e, this.stackFilter, this.color));

--- a/test/reporters/brief-test.js
+++ b/test/reporters/brief-test.js
@@ -750,6 +750,12 @@ helper.testCase("Brief reporter uncaught exceptions", {
 
         this.assertIO("Uncaught exception in Firefox 16.0 on Ubuntu 64-bit:");
         this.assertIO("TypeError: Expected a to be equal to b");
+    },
+
+    "does not barf when uncaughtException happens before tests start to run": function () {
+        this.runner.emit("uncaughtException", {});
+
+        this.assertIO("Uncaught exception in Unknown context:");
     }
 });
 


### PR DESCRIPTION
This changes output when using brief reported from `TypeError: uncaughtException listener threw error: Cannot read property 'description' of undefined` to `Uncaught exception in Unknown context: undefined`

Achievement unlocked.

Seriously though, this prevents a brief reporter crash, but still fails to report an actual error. Neither of the other reports do, because in the particular case when the browser throws _before_ any tests, the UncaughtError comes back inside the `e.data` - and I am not sure what to do in this case: should I check if `e.data` exists and pass that into `formatStack()`?

This is part of https://github.com/busterjs/buster/issues/422
