### PR TITLE
Fix #452. util.print is deprecated. Use console.log instead.

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -151,10 +151,10 @@
 
     function getOutputStream(opt) {
         if (opt.outputStream) { return opt.outputStream; }
+
         if (isNodeJS) {
-            var util = require("util");
             return {
-                write: function (bytes) { util.print(bytes); }
+                write: function (bytes) { process.stdout.write(bytes); }
             };
         }
     }

--- a/lib/reporters/specification.js
+++ b/lib/reporters/specification.js
@@ -2,9 +2,9 @@ var colorizer = require("ansi-colorizer");
 
 function getOutputStream(opt) {
     if (opt.outputStream) { return opt.outputStream; }
-    var util = require("util");
+
     return {
-        write: function (bytes) { util.print(bytes); }
+        write: function (bytes) { process.stdout.write(bytes); }
     };
 }
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -8,9 +8,9 @@ function label(test) {
 
 function getOutputStream(opt) {
     if (opt.outputStream) { return opt.outputStream; }
-    var util = require("util");
+
     return {
-        write: function (bytes) { util.print(bytes); }
+        write: function (bytes) { process.stdout.write(bytes); }
     };
 }
 

--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -29,9 +29,9 @@ function testName(test, contexts, min) {
 
 function getOutputStream(opt) {
     if (opt.outputStream) { return opt.outputStream; }
-    var util = require("util");
+
     return {
-        write: function (bytes) { util.print(bytes); }
+        write: function (bytes) { process.stdout.write(bytes); }
     };
 }
 

--- a/lib/reporters/xml.js
+++ b/lib/reporters/xml.js
@@ -39,9 +39,9 @@
 
     function getOutputStream(opt) {
         if (opt.outputStream) { return opt.outputStream; }
-        var util = require("util");
+
         return {
-            write: function (bytes) { util.print(bytes); }
+            write: function (bytes) { process.stdout.write(bytes); }
         };
     }
 


### PR DESCRIPTION
The deprecation error is coming from node@0.12. `console.log` should be safe to use in node@0.6.