### PR TITLE
Update .travis.yml to build in 0.8, 0.10, 0.12 and start faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,11 @@
 language: node_js
+node_js:
+  - "0.8"
+  - "0.10"
+  - "0.12"
+
+sudo: false
+
+before_install:
+  # use a more modern npm than ships with 0.8
+  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.8" ]; then npm install -g npm@1.4; fi'


### PR DESCRIPTION
Using `sudo: false` allows Travis to use faster VMs for running our tests