### PR TITLE
Update dependencies and shrinkwrap them

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,429 @@
+{
+  "name": "buster-test",
+  "version": "0.7.13",
+  "npm-shrinkwrap-version": "5.4.0",
+  "node-version": "v0.10.40",
+  "dependencies": {
+    "ansi-colorizer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-colorizer/-/ansi-colorizer-1.0.0.tgz"
+    },
+    "async": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+    },
+    "bane": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bane/-/bane-1.1.0.tgz"
+    },
+    "formatio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.2.tgz",
+      "dependencies": {
+        "samsam": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+        }
+      }
+    },
+    "jsdom": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-0.10.6.tgz",
+      "dependencies": {
+        "contextify": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
+          "dependencies": {
+            "bindings": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+            },
+            "nan": {
+              "version": "1.8.4",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+            }
+          }
+        },
+        "cssom": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
+        },
+        "cssstyle": {
+          "version": "0.2.29",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.29.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "domhandler": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            }
+          }
+        },
+        "nwmatcher": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
+        },
+        "request": {
+          "version": "2.60.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "bl": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "1.0.0-rc2",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc2.tgz"
+            },
+            "har-validator": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.9.34",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.8.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.12.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.8.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "hoek": {
+                  "version": "2.14.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.3.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.15.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.15.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+            },
+            "qs": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            }
+          }
+        },
+        "xmlhttprequest": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz"
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+    },
+    "platform": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.0.tgz"
+    },
+    "referee": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/referee/-/referee-1.1.1.tgz",
+      "dependencies": {
+        "bane": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bane/-/bane-1.0.0.tgz"
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
+        "samsam": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+        }
+      }
+    },
+    "sinon": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+        },
+        "lolex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
+        },
+        "samsam": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "stack-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stack-filter/-/stack-filter-1.0.0.tgz"
+    },
+    "when": {
+      "version": "1.8.1",
+      "from": "when@https://github.com/cujojs/when/tarball/1.8.1",
+      "resolved": "https://github.com/cujojs/when/tarball/1.8.1"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,70 +1,81 @@
 {
-    "name": "buster-test",
-    "version": "0.7.13",
-    "description": "Promised based evented xUnit and BDD style test runner for JavaScript",
-    "homepage": "http://docs.busterjs.org/en/latest/modules/buster-test/",
-    "author": "Christian Johansen",
-    "contributors": [{
-        "name": "Christian Johansen",
-        "email": "christian@cjohansen.no",
-        "url": "http://cjohansen.no"
-    }, {
-        "name": "August Lilleaas",
-        "email": "august.lilleaas@gmail.com",
-        "url": "http://augustl.com"
-    }, {
-        "name": "Calle Arnesten",
-        "email": "calle.arnesten@codekick.com"
-    }, {
-        "name": "Christoph Neuroth",
-        "email": "cnr@lusini.com"
-    }, {
-        "name": "Daniel Wittner",
-        "email": "d.wittner@gmx.de",
-        "url": "https://github.com/dwittner"
-    }, {
-        "name": "Fábio M. Costa",
-        "email": "fabiomcosta@gmail.com"
-    }, {
-        "name": "Malcolm Locke",
-        "email": "malc@wholemeal.co.nz"
-    }, {
-        "name": "Rodrigo Rosenfeld Rosas",
-        "email": "rr.rosas@gmail.com"
-    }, {
-        "name": "Rod Vagg",
-        "email": "rod@vagg.org",
-        "url": "http://vagg.org"
-    }, {
-        "name": "Stein Magnus Jodal",
-        "email": "stein.magnus@jodal.no",
-        "url": "http://jodal.no"
-    }],
-    "license": "BSD-3-Clause",
-    "main": "./lib/buster-test",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/busterjs/buster-test.git"
+  "name": "buster-test",
+  "version": "0.7.13",
+  "description": "Promised based evented xUnit and BDD style test runner for JavaScript",
+  "homepage": "http://docs.busterjs.org/en/latest/modules/buster-test/",
+  "author": "Christian Johansen",
+  "contributors": [
+    {
+      "name": "Christian Johansen",
+      "email": "christian@cjohansen.no",
+      "url": "http://cjohansen.no"
     },
-    "scripts": {
-        "test": "node run-tests.js",
-        "test-debug": "node --debug-brk run-tests.js"
+    {
+      "name": "August Lilleaas",
+      "email": "august.lilleaas@gmail.com",
+      "url": "http://augustl.com"
     },
-    "dependencies": {
-        "bane": "~1.0",
-        "ansi-colorizer": "~1.0",
-        "when": "https://github.com/cujojs/when/tarball/1.8.1",
-        "lodash": "~1.0",
-        "async": "~0.1",
-        "platform": "~1.2"
+    {
+      "name": "Calle Arnesten",
+      "email": "calle.arnesten@codekick.com"
     },
-    "optionalDependencies": {
-        "jsdom": "~0.10"
+    {
+      "name": "Christoph Neuroth",
+      "email": "cnr@lusini.com"
     },
-    "devDependencies": {
-        "stack-filter": "~1.0",
-        "referee": "*",
-        "formatio": "*",
-        "sinon": "~1.4"
+    {
+      "name": "Daniel Wittner",
+      "email": "d.wittner@gmx.de",
+      "url": "https://github.com/dwittner"
+    },
+    {
+      "name": "Fábio M. Costa",
+      "email": "fabiomcosta@gmail.com"
+    },
+    {
+      "name": "Malcolm Locke",
+      "email": "malc@wholemeal.co.nz"
+    },
+    {
+      "name": "Rodrigo Rosenfeld Rosas",
+      "email": "rr.rosas@gmail.com"
+    },
+    {
+      "name": "Rod Vagg",
+      "email": "rod@vagg.org",
+      "url": "http://vagg.org"
+    },
+    {
+      "name": "Stein Magnus Jodal",
+      "email": "stein.magnus@jodal.no",
+      "url": "http://jodal.no"
     }
+  ],
+  "license": "BSD-3-Clause",
+  "main": "./lib/buster-test",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/busterjs/buster-test.git"
+  },
+  "scripts": {
+    "test": "node run-tests.js",
+    "test-debug": "node --debug-brk run-tests.js"
+  },
+  "dependencies": {
+    "ansi-colorizer": "~1.0",
+    "async": "^1.4.0",
+    "bane": "^1.1.0",
+    "lodash": "^3.1.0",
+    "platform": "^1.3.0",
+    "when": "https://github.com/cujojs/when/tarball/1.8.1"
+  },
+  "optionalDependencies": {
+    "jsdom": "~0.10"
+  },
+  "devDependencies": {
+    "formatio": "*",
+    "referee": "*",
+    "sinon": "^1.15.4",
+    "stack-filter": "~1.0"
+  }
 }


### PR DESCRIPTION
Shipping code with loose depenency version strings always leads to
problems at the least opportune moment: during an important
deployment by someone unfamiliar with the codebase.

In order to avoid this situation for our users, I would recommended
only using frozen dependencies via `npm shrinkwrap`.

* [Managing Node.js Dependencies with Shrinkwrap](http://blog.nodejs.org/2012/02/27/managing-node-js-dependencies-with-shrinkwrap/)
* [`npm shrinkwrap`](https://docs.npmjs.com/cli/shrinkwrap)
* [The limitations of semantic versioning](http://nolanlawson.com/2014/09/01/the-limitations-of-semantic-versioning/)

I'll prepare a pull request into busterjs/buster with details on how
this process can work, so that it's easily repeatable.